### PR TITLE
Fix: Add test/fixtures read permission to foundry.toml (#8)

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -15,7 +15,8 @@ remappings = [
 # I can't tell why foundry wants the path to be exact but it does not work for me
 fs_permissions = [
     { access = "read-write", path = "./artifacts" },
-    { access = "read", path = "./.nodes" }
+    { access = "read", path = "./.nodes" },
+    { access = "read", path = "./test/fixtures" }
 ]
 
 [rpc_endpoints]


### PR DESCRIPTION
## Summary
- Adds read permission for `test/fixtures` directory in foundry.toml
- Fixes failing test `test_account_proof_verification` that was unable to read JSON fixture files
- Resolves issue #8

## Context
The test was failing with:
```
vm.readFile: the path test/fixtures/counterProof_3675746.json is not allowed to be accessed for read operations
```

## Changes
Updated `contracts/foundry.toml` to include read permissions for the test fixtures directory.

## Test Plan
- [x] Run `forge test --match-test test_account_proof_verification` - test now passes
- [x] Verify all other tests still pass

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)